### PR TITLE
ENG-2849 : added support for customResourceAttributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middleware.io/node-apm",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Middleware exporter for NodeJS",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import process from 'process';
 import {init as tracerInit} from './tracer-collector';
 import {init as metricInit} from './metrics-collector';
 import { loggerInitializer } from './logger';
+import { ResourceAttributes } from '@opentelemetry/resources';
 
 export interface Config {
     pauseMetrics: Boolean | number;
@@ -24,8 +25,11 @@ export interface Config {
     consoleLog: boolean;
     consoleError:boolean;
     meterProvider:any,
-    isServerless:boolean
+    isServerless:boolean,
+    customResourceAttributes: ResourceAttributes
 }
+
+let customResourceAttributes: ResourceAttributes = {};
 
 export let configDefault: Config = {
     DEBUG: false,
@@ -48,6 +52,7 @@ export let configDefault: Config = {
     pauseMetrics:false,
     meterProvider:false,
     isServerless:false,
+    customResourceAttributes: customResourceAttributes,
 };
 
 export const init = (config: Partial<Config> = {}): Config => {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -41,6 +41,7 @@ export const loggerInitializer = (config: Config): void => {
             ['project.name']: config.projectName,
             ['mw.account_key']: config.accessToken,
             ['mw_serverless']:config.isServerless ? 1 : 0,
+            ...config.customResourceAttributes
         })
     });
 

--- a/src/metrics-collector.ts
+++ b/src/metrics-collector.ts
@@ -28,6 +28,7 @@ export const init = (config: Config): void => {
             ['runtime.metrics.nodejs']: true,
             ['mw.app.lang']: 'nodejs',
             ['mw_serverless']:config.isServerless ? 1 : 0,
+            ...config.customResourceAttributes
         }),
         readers : [metricReader]
     });

--- a/src/tracer-collector.ts
+++ b/src/tracer-collector.ts
@@ -39,6 +39,7 @@ export const init = (config: Config) => {
                 ['project.name']: config.projectName,
                 ['mw.account_key']: config.accessToken,
                 ['mw_serverless']:config.isServerless ? 1 : 0,
+                ...config.customResourceAttributes
             })
         );
 


### PR DESCRIPTION
Allowed Users to add custom resource attributes [ This will replicate in 3 pipelines : Metrics, Traces & Logs ]

We will ask clients to pass deployment version like this :

```
tracker.track({
  serviceName: "demo-application",
  customResourceAttributes: {
    "service.deployment.version": "1.0.0"
  }
});
```