### PR TITLE
ENG-3103: Add Node types for wrappers not inherited 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@middleware.io/node-apm",
-  "version": "1.3.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@middleware.io/node-apm",
-      "version": "1.3.0",
+      "version": "1.5.0",
       "license": "ISC",
       "dependencies": {
         "@grpc/grpc-js": "^1.6.7",
@@ -41,7 +41,8 @@
       },
       "devDependencies": {
         "@types/mongodb": "^4.0.7",
-        "@types/node": "^20.12.11"
+        "@types/node": "^20.14.2",
+        "typescript": "^5.4.5"
       }
     },
     "node_modules/@colors/colors": {
@@ -2731,9 +2732,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.12.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.11.tgz",
-      "integrity": "sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==",
+      "version": "20.14.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
+      "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -5708,6 +5709,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middleware.io/node-apm",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Middleware exporter for NodeJS",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
@@ -55,6 +55,7 @@
   "homepage": "https://github.com/middleware-labs/node-apm-ts#readme",
   "devDependencies": {
     "@types/mongodb": "^4.0.7",
-    "@types/node": "^20.12.11"
+    "@types/node": "^20.14.2",
+    "typescript": "^5.4.5"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,7 +41,7 @@ export let configDefault: Config = {
         fluent: 8006,
     },
     target: 'http://localhost:9319',
-    profilingServerUrl: 'https://profiling.middleware.io',
+    profilingServerUrl: '',
     enableProfiling: true,
     accessToken: '',
     tenantID: '',

--- a/src/init.ts
+++ b/src/init.ts
@@ -3,7 +3,7 @@ import { log } from './logger';
 import { init as configInit } from './config';
 import { init as profilerInit } from './profiler';
 import {Config,configDefault} from './config';
-
+import {Meter as IMeter, MeterOptions ,TracerOptions, Tracer} from '@opentelemetry/api';
 export const track = (newConfig: Partial<Config> | undefined = {}): void => {
     const config = configInit(newConfig);
     profilerInit(config).then(r => {});
@@ -44,12 +44,13 @@ export const setAttribute = (name: string, value: any): void => {
     }
 };
 
-export const getMeter =() => {
+export const getMeter = (name: string, version?: string, options?: MeterOptions): IMeter => {
     if (configDefault.meterProvider){
         return configDefault.meterProvider.getMeter(configDefault.serviceName)
     }
-    return false
+    return otel.meter.getMeter(configDefault.serviceName)
 }
-export const getTracer =() => {
+
+export const getTracer =(name: string, version?: string, options?: TracerOptions): Tracer => {
     return otel.trace.getTracer(configDefault.serviceName)
 }

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -22,7 +22,9 @@ export const init = async (config: Config): Promise<Config> => {
 
                     if (typeof account === 'string') {
                         const TenantID = account;
-
+                        
+                        config.profilingServerUrl = `https://${account}.middleware.io/profiling`
+                        
                         const profilingServerUrl = process.env.MW_PROFILING_SERVER_URL || config.profilingServerUrl;
 
                         Pyroscope.init({


### PR DESCRIPTION
- added types for `getMeter` and `getTracer`.
- updated profiling server url for v2 support.