### PR TITLE
Added options to exclude spans based on HTTP URL and Methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@middleware.io/node-apm",
-  "version": "2.2.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@middleware.io/node-apm",
-      "version": "2.2.0",
+      "version": "2.3.1",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middleware.io/node-apm",
-  "version": "2.2.0",
+  "version": "2.3.1",
   "description": "Middleware exporter for NodeJS",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",


### PR DESCRIPTION
# HTTP Trace Exclusion Configuration

This PR introduces a new, more flexible configuration system for excluding HTTP requests from tracing. The new system provides granular control over incoming and outgoing HTTP requests separately.

## 🆕 New Configuration Structure

### Programmatic Configuration

```javascript
const mw = require('@middleware.io/node-apm');

mw.track({
  excludeHttpTraces: {
    incoming: {
      urls: ['/health', '/metrics', '/status'],
      methods: ['OPTIONS', 'HEAD']
    },
    outgoing: {
      urls: ['/internal-api', '/telemetry', '/profiling'],
      methods: ['TRACE']
    }
  }
});
```

### Environment Variables

```bash
# Exclude incoming requests
MW_EXCLUDE_INCOMING_HTTP_METHODS="OPTIONS,HEAD,TRACE"
MW_EXCLUDE_INCOMING_HTTP_URLS="/health,/metrics,/status"

# Exclude outgoing requests  
MW_EXCLUDE_OUTGOING_HTTP_METHODS="TRACE"
MW_EXCLUDE_OUTGOING_HTTP_URLS="/internal-api,/telemetry,/profiling"
```

## 🎯 Use Cases

### 1. Health Check Endpoints
Exclude health check endpoints from incoming request tracing:

```javascript
excludeHttpTraces: {
  incoming: {
    urls: ['/health', '/ready', '/live']
  }
}
```

```bash
MW_EXCLUDE_INCOMING_HTTP_URLS="/health,/ready,/live"