### PR TITLE
AGE-334 : export errorHandler for NestJs and fastify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@middleware.io/node-apm",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@middleware.io/node-apm",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@middleware.io/node-apm",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Middleware exporter for NodeJS",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/src/config.ts
+++ b/src/config.ts
@@ -136,6 +136,8 @@ export function computeOptions(config: Partial<Config> = {}) {
   config.enableSelfInstrumentation =
     parseBoolean(process.env.MW_SELF_INSTRUMENTATION) ??
     config.enableSelfInstrumentation;
+  config.enableProfiling =
+    parseBoolean(process.env.MW_PROFILING_ENABLED) ?? config.enableProfiling;
   
   // Handle HTTP trace exclusions with environment variable precedence
   const incomingExcludedMethods = process.env.MW_EXCLUDE_INCOMING_HTTP_METHODS;

--- a/src/init.ts
+++ b/src/init.ts
@@ -15,7 +15,7 @@ import { performHealthCheck } from "./healthcheck";
 import { shutdown } from "./tracer-collector";
 
 import { Express } from 'express';
-import errorHandler from './errorhandler';
+import ErrorHandler from './errorhandler';
 
 
 export const track = (newConfig: Partial<Config> | undefined = {}): void => {
@@ -99,5 +99,7 @@ export const getTracer = (
 
 // Function to register the error handler
 export function registerErrorHandler(app: Express): void {
-  app.use(errorHandler);
+  app.use(ErrorHandler);
 }
+
+export const errorHandler = ErrorHandler;


### PR DESCRIPTION
- added support for `errorHandler` function.
- covers `express`, `nestjs` and `fastify` web frameworks.
- will be able to set errorHandler as a wrapper inside global errorHandler

### Fastify:
```
const middleware = require('@middleware.io/node-apm');
const fastify = require('fastify')({ logger: true });

// Register Middleware.io error handler for Fastify
fastify.setErrorHandler((error, request, reply) => {
    middleware.errorHandler(error, request, reply);
    // Optionally, send a response
    reply.status(500).send({ error: error.message });
});

const start = async () => {
    try {
        await fastify.listen({ port: 8080, host: '0.0.0.0' });
        fastify.log.info(`E-commerce app listening at http://0.0.0.0:8080`);
    } catch (err) {
        fastify.log.error(err);
        process.exit(1);
    }
};
start();
```

### Nest.Js
```
import { NestFactory } from '@nestjs/core';
import { AppModule } from './app.module';
import { errorHandler } from '@middleware.io/node-apm';
import { Catch, ArgumentsHost, ExceptionFilter } from '@nestjs/common';

@Catch()
export class ExpressErrorAdapterFilter implements ExceptionFilter {
  catch(exception: any, host: ArgumentsHost) {
    const ctx = host.switchToHttp();
    const req = ctx.getRequest();
    const res = ctx.getResponse();
    const next = ctx.getNext();
    // Call your existing Express-style error handler
    errorHandler(exception, req, res, next);
  }
}

async function bootstrap() {
  const app = await NestFactory.create(AppModule);
  app.useGlobalFilters(new ExpressErrorAdapterFilter());
  await app.listen(3000);
}
bootstrap();
```